### PR TITLE
feat: Sprint 1 — foundation hardening (P0 fixes)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,5 +10,6 @@
   "repository": "https://github.com/SkyWalker2506/ccplugin-agent-browser",
   "license": "MIT",
   "category": "development",
-  "keywords": ["browser", "automation", "headless", "playwright", "scrape", "screenshot", "testing", "e2e"]
+  "keywords": ["browser", "automation", "headless", "playwright", "scrape", "screenshot", "testing", "e2e"],
+  "install": "bash setup.sh"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Node
+node_modules/
+npm-debug.log*
+
+# Forge / analysis artifacts
+forge/
+analysis/
+.jira-state/
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo

--- a/commands/agent-browser.md
+++ b/commands/agent-browser.md
@@ -102,6 +102,8 @@ agent-browser auth login myapp
 agent-browser --profile ~/.myapp open https://app.com/login
 ```
 
+> **Security:** Always pass passwords via `--password-stdin` (pipe from env var). Never pass a password as a CLI argument — it will be visible in shell history and process listings.
+
 ## Chaining
 
 Chain commands with `&&` when intermediate output is not needed:

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,42 @@
 #!/usr/bin/env bash
 # setup.sh — Install agent-browser and its Chromium dependency
 
-set -e
+set -euo pipefail
 
-echo "Installing agent-browser..."
-npm install -g agent-browser
+# ── Prerequisites ──────────────────────────────────────────────────────────────
+if ! command -v node >/dev/null 2>&1; then
+  echo "❌ Node.js not found. Install Node.js 18+ first: https://nodejs.org" >&2
+  exit 1
+fi
 
-echo "Downloading Chromium (required for browser automation)..."
-agent-browser install
+NODE_MAJOR=$(node -e 'process.stdout.write(process.version.slice(1).split(".")[0])')
+if [ "$NODE_MAJOR" -lt 18 ]; then
+  echo "❌ Node.js 18+ required (found $(node --version)). Upgrade at https://nodejs.org" >&2
+  exit 1
+fi
 
-echo "Done. You can now use agent-browser commands."
+if ! command -v npm >/dev/null 2>&1; then
+  echo "❌ npm not found. Install npm (bundled with Node.js 18+)." >&2
+  exit 1
+fi
+
+# ── Install ────────────────────────────────────────────────────────────────────
+echo "▶ Installing agent-browser..."
+if ! npm install -g agent-browser; then
+  echo "❌ npm install failed. Try: sudo npm install -g agent-browser" >&2
+  exit 1
+fi
+
+# ── Chromium (idempotent) ──────────────────────────────────────────────────────
+if agent-browser --version >/dev/null 2>&1 && agent-browser check-install >/dev/null 2>&1; then
+  echo "✓ Chromium already installed — skipping download."
+else
+  echo "▶ Downloading Chromium (required for browser automation)..."
+  if ! agent-browser install; then
+    echo "❌ Chromium download failed. Check network connectivity." >&2
+    exit 1
+  fi
+fi
+
+echo ""
+echo "✅ agent-browser is ready. Run: agent-browser open https://example.com"

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -43,6 +43,8 @@ echo "$PASS" | agent-browser auth save myapp --url https://app.com/login --usern
 agent-browser auth login myapp
 ```
 
+> **Security:** Always pass passwords via `--password-stdin` (pipe from env var). Never pass a password as a CLI argument — it will be visible in shell history and process listings.
+
 **Persistent profile:**
 ```bash
 agent-browser --profile ~/.myapp open https://app.com/login


### PR DESCRIPTION
## Summary

- **T1-1:** SKILL.md ↔ commands/agent-browser.md content parity + security note added to auth sections
- **T1-2:** setup.sh hardened — Node.js 18+ prereq check, meaningful error messages, idempotent Chromium install
- **T1-3:** plugin.json \`install\` field added (\`"install": "bash setup.sh"\`)
- **T1-4:** .gitignore added (.DS_Store, node_modules, forge/, analysis/)

## Test plan
- [x] \`bash -n setup.sh\` passes
- [x] plugin.json valid JSON
- [x] Security note present in both SKILL.md and commands/agent-browser.md

Closes #2