### PR TITLE
fix: Sprint 3 — polish & DX consistency pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.0.2] — 2026-04-22
+
+### Fixed
+- `commands/agent-browser.md`: `allowed-tools` converted from JSON inline array to proper YAML sequence format
+- `SKILL.md`: Added cross-link to `commands/agent-browser.md` for discoverability
+
 ## [1.0.1] — 2026-04-22
 
 ### Added

--- a/commands/agent-browser.md
+++ b/commands/agent-browser.md
@@ -1,6 +1,10 @@
 ---
 description: Headless browser automation — navigate pages, fill forms, click buttons, take screenshots, scrape data, and run e2e tests
-allowed-tools: [Bash(npx agent-browser:*), Bash(agent-browser:*), Bash, Read]
+allowed-tools:
+  - Bash(npx agent-browser:*)
+  - Bash(agent-browser:*)
+  - Bash
+  - Read
 ---
 
 # Browser Automation CLI

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -7,7 +7,8 @@ version: 1.0.0
 
 # Browser Automation — agent-browser
 
-Install: `npm i -g agent-browser` then `agent-browser install` (downloads Chromium).
+Install: `npm i -g agent-browser` then `agent-browser install` (downloads Chromium).  
+Full slash-command reference: see `commands/agent-browser.md` or use `/agent-browser`.
 
 ## Core Workflow
 


### PR DESCRIPTION
## Summary

- **T3-1:** `eval --stdin` already present in SKILL.md — confirmed, no change needed
- **T3-2:** Uninstall section completed in Sprint 2
- **T3-3:** Consistency pass:
  - `commands/agent-browser.md`: `allowed-tools` converted from JSON inline array `[...]` to proper YAML sequence format (Claude Code spec compliance)
  - `SKILL.md`: cross-link to `commands/agent-browser.md` added for discoverability
  - `CHANGELOG.md`: v1.0.2 entry added

## Test plan
- [x] YAML frontmatter valid (proper sequence format)
- [x] Cross-link present in SKILL.md

Closes #4
Closes #1